### PR TITLE
Per-buffer whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,15 +72,15 @@ Whitespace highlighting is enabled by default, with a highlight color of red.
     :ToggleStripWhitespaceOnSave
     ```
     This will strip all trailing whitespace everytime you save the file for all file types.
-    
+
     *  If you want this behaviour by default for all filetypes, add the following to your `~/.vimrc`:
-        
+
         ```
         autocmd BufWritePre * StripWhitespace
         ```
-        
+
         For exceptions of all see ```g:better_whitespace_filetypes_blacklist```.
-        
+
     *  If you would prefer to only stip whitespace for certain filetypes, add
         the following to your `~/.vimrc`:
 
@@ -95,17 +95,18 @@ Whitespace highlighting is enabled by default, with a highlight color of red.
 
 *  To disable this plugin for specific file types, add the following to your `~/.vimrc`:
     ```
-    let g:better_whitespace_filetypes_blacklist+=['<filetype1>', '<filetype2>', '<etc>']
+    let g:better_whitespace_filetypes_blacklist=['<filetype1>', '<filetype2>', '<etc>']
     ```
-    This adds filetypes to the default list of blacklisted filetypes. The
+    This replaces the filetypes from the default list of blacklisted filetypes. The
     default types that are blacklisted are:
     ```
     ['diff', 'gitcommit', 'unite', 'qf', 'help']
     ```
-    If you do not want any of these filetypes ignored, simply reset the
-    blacklist rather than append to it:
+    If you do not want any of these filetypes unignored, simply include them in the
+    blacklist:
     ```
-    let g:better_whitespace_filetypes_blacklist=['<filetype1>', '<filetype2>', '<etc>']
+    let g:better_whitespace_filetypes_blacklist=['<filetype1>', '<filetype2>', '<etc>',
+                                            'diff', 'gitcommit', 'unite', 'qf', 'help']
     ```
 
 *  To enable verbose output for each command, set verbosity in your `.vimrc`:

--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -191,10 +191,11 @@ command! CurrentLineWhitespaceOn call <SID>CurrentLineWhitespaceOn()
 
 " Process auto commands upon load, update local enabled on filetype change
 autocmd FileType * let b:better_whitespace_enabled = !<SID>ShouldSkipHighlight() | call <SID>SetupAutoCommands()
-autocmd WinEnter,BufWinEnter * call <SID>SetupAutoCommands()
+autocmd BufWinEnter * call <SID>SetupAutoCommands()
 autocmd ColorScheme * call <SID>WhitespaceInit()
 
 function! s:PerformMatchHighlight(pattern)
+    call s:InitVariable('b:better_whitespace_enabled', !<SID>ShouldSkipHighlight())
     if b:better_whitespace_enabled == 1
         exe 'match ExtraWhitespace ' . a:pattern
     else
@@ -204,6 +205,7 @@ endfunction
 
 function! s:PerformSyntaxHighlight(pattern)
     syn clear ExtraWhitespace
+    call s:InitVariable('b:better_whitespace_enabled', !<SID>ShouldSkipHighlight())
     if b:better_whitespace_enabled == 1
         exe 'syn match ExtraWhitespace excludenl ' . a:pattern
     endif
@@ -215,9 +217,6 @@ function! <SID>SetupAutoCommands()
     augroup better_whitespace
         autocmd!
 
-        " make sure the local variable exists
-        call s:InitVariable('b:better_whitespace_enabled', !<SID>ShouldSkipHighlight())
-
         if g:better_whitespace_enabled == 1
             if s:better_whitespace_initialized == 0
                 call <SID>WhitespaceInit()
@@ -227,7 +226,6 @@ function! <SID>SetupAutoCommands()
             if g:current_line_whitespace_disabled_soft == 0
                 " Highlight all whitespace upon entering buffer
                 call <SID>PerformMatchHighlight('/\s\+$/')
-                autocmd BufWinEnter * call <SID>PerformMatchHighlight('/\s\+$/')
                 " Check if current line highglighting is disabled
                 if g:current_line_whitespace_disabled_hard == 1
                     " Never highlight whitespace on current line

--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -10,9 +10,9 @@ let g:loaded_better_whitespace_plugin = 1
 " Initializes a given variable to a given value. The variable is only
 " initialized if it does not exist prior.
 function! s:InitVariable(var, value)
-  if !exists(a:var)
-    execute 'let ' . a:var . ' = ' . string(a:value)
-  endif
+    if !exists(a:var)
+      execute 'let ' . a:var . ' = ' . string(a:value)
+    endif
 endfunction
 
 " Set this to enable/disable whitespace highlighting

--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -191,7 +191,7 @@ command! CurrentLineWhitespaceOn call <SID>CurrentLineWhitespaceOn()
 
 " Process auto commands upon load, update local enabled on filetype change
 autocmd FileType * let b:better_whitespace_enabled = !<SID>ShouldSkipHighlight() | call <SID>SetupAutoCommands()
-autocmd BufWinEnter * call <SID>SetupAutoCommands()
+autocmd WinEnter,BufWinEnter * call <SID>SetupAutoCommands()
 autocmd ColorScheme * call <SID>WhitespaceInit()
 
 function! s:PerformMatchHighlight(pattern)

--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -79,11 +79,9 @@ endfunction
 
 " Enable the whitespace highlighting
 function! s:EnableWhitespace()
-    if g:better_whitespace_enabled == 0
-        let g:better_whitespace_enabled = 1
+    if b:better_whitespace_enabled == 0
+        let b:better_whitespace_enabled = 1
         call <SID>WhitespaceInit()
-        " Match default whitespace
-        call s:InAllWindows('match ExtraWhitespace /\s\+$/')
         call <SID>SetupAutoCommands()
         call <SID>Echo("Whitespace Highlighting: Enabled")
     endif
@@ -91,10 +89,8 @@ endfunction
 
 " Disable the whitespace highlighting
 function! s:DisableWhitespace()
-    if g:better_whitespace_enabled == 1
-        let g:better_whitespace_enabled = 0
-        " Clear current whitespace matches
-        call s:InAllWindows("match ExtraWhitespace '' | syn clear ExtraWhitespace")
+    if b:better_whitespace_enabled == 1
+        let b:better_whitespace_enabled = 0
         call <SID>SetupAutoCommands()
         call <SID>Echo("Whitespace Highlighting: Disabled")
     endif
@@ -102,7 +98,7 @@ endfunction
 
 " Toggle whitespace highlighting on/off
 function! s:ToggleWhitespace()
-    if g:better_whitespace_enabled == 1
+    if b:better_whitespace_enabled == 1
         call <SID>DisableWhitespace()
     else
         call <SID>EnableWhitespace()
@@ -193,9 +189,25 @@ command! -nargs=* CurrentLineWhitespaceOff call <SID>CurrentLineWhitespaceOff( <
 " Run :CurrentLineWhitespaceOn to turn on whitespace for the current line
 command! CurrentLineWhitespaceOn call <SID>CurrentLineWhitespaceOn()
 
-" Process auto commands upon load
-autocmd BufWinEnter,FileType * call <SID>SetupAutoCommands()
+" Process auto commands upon load, update local enabled on filetype change
+autocmd FileType * let b:better_whitespace_enabled = !<SID>ShouldSkipHighlight() | call <SID>SetupAutoCommands()
+autocmd BufWinEnter * call <SID>SetupAutoCommands()
 autocmd ColorScheme * call <SID>WhitespaceInit()
+
+function! s:PerformMatchHighlight(pattern)
+    if b:better_whitespace_enabled == 1
+        exe 'match ExtraWhitespace ' . a:pattern
+    else
+        match ExtraWhitespace ''
+    endif
+endfunction
+
+function! s:PerformSyntaxHighlight(pattern)
+    syn clear ExtraWhitespace
+    if b:better_whitespace_enabled == 1
+        exe 'syn match ExtraWhitespace excludenl ' . a:pattern
+    endif
+endfunction
 
 " Executes all auto commands
 function! <SID>SetupAutoCommands()
@@ -203,10 +215,8 @@ function! <SID>SetupAutoCommands()
     augroup better_whitespace
         autocmd!
 
-        if <SID>ShouldSkipHighlight()
-            match ExtraWhitespace ''
-            return
-        endif
+        " make sure the local variable exists
+        call s:InitVariable('b:better_whitespace_enabled', !<SID>ShouldSkipHighlight())
 
         if g:better_whitespace_enabled == 1
             if s:better_whitespace_initialized == 0
@@ -216,25 +226,26 @@ function! <SID>SetupAutoCommands()
             " Check if current line is disabled softly
             if g:current_line_whitespace_disabled_soft == 0
                 " Highlight all whitespace upon entering buffer
-                autocmd BufWinEnter * match ExtraWhitespace /\s\+$/
+                call <SID>PerformMatchHighlight('/\s\+$/')
+                autocmd BufWinEnter * call <SID>PerformMatchHighlight('/\s\+$/')
                 " Check if current line highglighting is disabled
                 if g:current_line_whitespace_disabled_hard == 1
                     " Never highlight whitespace on current line
-                    autocmd InsertEnter,CursorMoved,CursorMovedI * exe 'match ExtraWhitespace ' . '/\%<' . line(".") .  'l\s\+$\|\%>' . line(".") .  'l\s\+$/'
+                    autocmd InsertEnter,CursorMoved,CursorMovedI * call <SID>PerformMatchHighlight('/\%<' . line(".") .  'l\s\+$\|\%>' . line(".") .  'l\s\+$/')
                 else
                     " When in insert mode, do not highlight whitespace on the current line
-                    autocmd InsertEnter,CursorMovedI * exe 'match ExtraWhitespace ' . '/\%<' . line(".") .  'l\s\+$\|\%>' . line(".") .  'l\s\+$/'
+                    autocmd InsertEnter,CursorMovedI * call <SID>PerformMatchHighlight('/\%<' . line(".") .  'l\s\+$\|\%>' . line(".") .  'l\s\+$/')
                 endif
                 " Highlight all whitespace when exiting insert mode
-                autocmd InsertLeave,BufReadPost * match ExtraWhitespace /\s\+$/
+                autocmd InsertLeave,BufReadPost * call <SID>PerformMatchHighlight('/\s\+$/')
                 " Clear whitespace highlighting when leaving buffer
                 autocmd BufWinLeave * match ExtraWhitespace ''
             else
                 " Highlight extraneous whitespace at the end of lines, but not the
                 " current line.
-                call s:InAllWindows('syn clear ExtraWhitespace | syn match ExtraWhitespace excludenl /\s\+$/')
-                autocmd InsertEnter * syn clear ExtraWhitespace | syn match ExtraWhitespace excludenl /\s\+\%#\@!$/ containedin=ALLBUT,gitcommitDiff
-                autocmd InsertLeave,BufReadPost * syn clear ExtraWhitespace | syn match ExtraWhitespace excludenl /\s\+$/ containedin=ALLBUT,gitcommitDiff
+                call <SID>PerformSyntaxHighlight('/\s\+$/')
+                autocmd InsertEnter * call <SID>PerformSyntaxHighlight('/\s\+\%#\@!$/')
+                autocmd InsertLeave,BufReadPost * call <SID>PerformSyntaxHighlight('/\s\+$/')
             endif
         endif
 
@@ -246,5 +257,3 @@ function! <SID>SetupAutoCommands()
     augroup END
 endfunction
 
-" Initial call to setup autocommands
-call <SID>SetupAutoCommands()


### PR DESCRIPTION
This PR enables per buffer enable/disable/toggle of whitespace highlighting, by wrapping the actual syntax highlighting in functions that check a buffer-local variable before highlighting. This variable (`b:better_whitespace_enabled`) is set to a sensible default, guessed from the blacklist and updated if the file type changes.

The global `g:better_whitespace_enabled` still exists and completely disables whitespace highlighting if it is set to `0`.

Including the initial un/redraw from Enable/Disable inside `SetupAutoCommands` and twiddling with the choice of events that trigger the setup allows to fix various bugs, at least for me with vim 7.4 (2013 Aug 10).


PS: Sorry for the noise on the issues, I managed to forget one of your commits and had to force-push.