### PR TITLE
Highlight whitespace on both BufEnter and WinEnter for e.g. split

### DIFF
--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -191,7 +191,8 @@ command! CurrentLineWhitespaceOn call <SID>CurrentLineWhitespaceOn()
 
 " Process auto commands upon load, update local enabled on filetype change
 autocmd FileType * let b:better_whitespace_enabled = !<SID>ShouldSkipHighlight() | call <SID>SetupAutoCommands()
-autocmd BufWinEnter * call <SID>SetupAutoCommands()
+autocmd BufEnter * call <SID>SetupAutoCommands()
+autocmd WinEnter * call <SID>SetupAutoCommands()
 autocmd ColorScheme * call <SID>WhitespaceInit()
 
 function! s:PerformMatchHighlight(pattern)

--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -191,8 +191,7 @@ command! CurrentLineWhitespaceOn call <SID>CurrentLineWhitespaceOn()
 
 " Process auto commands upon load, update local enabled on filetype change
 autocmd FileType * let b:better_whitespace_enabled = !<SID>ShouldSkipHighlight() | call <SID>SetupAutoCommands()
-autocmd BufEnter * call <SID>SetupAutoCommands()
-autocmd WinEnter * call <SID>SetupAutoCommands()
+autocmd WinEnter,BufWinEnter * call <SID>SetupAutoCommands()
 autocmd ColorScheme * call <SID>WhitespaceInit()
 
 function! s:PerformMatchHighlight(pattern)


### PR DESCRIPTION
See issue #45

To resolve this i've changed the hook to be for both BufEnter and WinEnter. Let me know if there's anything further I can do around this!