### PR TITLE
Add option to strip white lines at EOF, closes #67

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Whitespace highlighting is enabled by default, with a highlight color of red.
                                             'diff', 'gitcommit', 'unite', 'qf', 'help']
     ```
 
+*  To strip white lines at the end of the file when stripping whitespace, set this option in your `.vimrc`:
+    ```
+    let g:strip_whitelines_at_eof=1
+    ```
+
 *  To enable verbose output for each command, set verbosity in your `.vimrc`:
     ```
     let g:better_whitespace_verbosity=1

--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -32,6 +32,10 @@ call s:InitVariable('g:current_line_whitespace_disabled_soft', 0)
 " Set this to enable stripping whitespace on file save
 call s:InitVariable('g:strip_whitespace_on_save', 0)
 
+" Set this to enable stripping white lines at the end of the file when we
+" strip whitespace
+call s:InitVariable('g:strip_whitelines_at_eof', 0)
+
 " Set this to blacklist specific filetypes
 let default_blacklist=['diff', 'gitcommit', 'unite', 'qf', 'help', 'markdown']
 call s:InitVariable('g:better_whitespace_filetypes_blacklist', default_blacklist)
@@ -155,6 +159,18 @@ function! s:StripWhitespace( line1, line2 )
 
     " Strip the whitespace
     silent! execute ':' . a:line1 . ',' . a:line2 . 's/' . s:eol_whitespace_pattern . '//e'
+
+    " Strip empty lines at EOF
+    if g:strip_whitelines_at_eof == 1
+        if &ff == 'dos'
+            let nl='\r\n'
+        elseif &ff == 'max'
+            let nl='\r'
+        else " unix
+            let nl='\n'
+        endif
+        silent! execute '%s/\('.nl.'\)\+\%$//'
+    endif
 
     " Restore the saved search and cursor position
     let @/=_s


### PR DESCRIPTION
Simple trailing white line removal as suggested in feature request #67. Introduces a new option (disabled by default).

Supports different line endings based on file format (not mixed files). Relies on matching end of line with `\%$`.

To support files with inconsistent new lines the pattern could simply be `[\r\n]\+\%$` but I don't know if that is desirable, this could mess with for example a unix-file having a (bunch of) `\r` in its last line(s).