### PR TITLE
Add operator for StripWhitespace (defaults to space)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ Whitespace highlighting is enabled by default, with a highlight color of red.
     the file that it cleans, either give it a range or select a group of lines
     in visual mode and then execute it.
 
+    *  There is an operator (defaulting to `<space>`) to clean whitespace.
+        For example, in normal mode, `<space>ip` will remove trailing whitespace from the
+        current paragraph.
+
+        You can change the operator it, for example to set it to _s, using:
+        ```vim
+        let g:better_whitespace_operator='_s'
+        ```
+        Now `<number>_s<space>` strips whitespace on \<number\> lines, and `_s<motion>` on the
+        lines affected by the motion given. Set to the empty string to deactivate the operator.
+
 *  To enable/disable stripping of extra whitespace on file save, call:
     ```
     :ToggleStripWhitespaceOnSave

--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -15,6 +15,9 @@ function! s:InitVariable(var, value)
     endif
 endfunction
 
+" Operator for StripWhitespace (empty to disable)
+call s:InitVariable('g:better_whitespace_operator', '<space>')
+
 " Set this to enable/disable whitespace highlighting
 call s:InitVariable('g:better_whitespace_enabled', 1)
 
@@ -208,6 +211,20 @@ command! ToggleWhitespace call <SID>ToggleWhitespace()
 command! -nargs=* CurrentLineWhitespaceOff call <SID>CurrentLineWhitespaceOff( <f-args> )
 " Run :CurrentLineWhitespaceOn to turn on whitespace for the current line
 command! CurrentLineWhitespaceOn call <SID>CurrentLineWhitespaceOn()
+
+if !empty('g:better_whitespace_operator')
+    function! s:StripWhitespaceMotion(type)
+        call <SID>StripWhitespace(line("'["), line("']"))
+    endfunction
+
+    " Visual mode
+    exe "xmap <silent> ".g:better_whitespace_operator." :StripWhitespace<CR>"
+    " Normal mode (+ space, with line count)
+    exe "nmap <silent> ".g:better_whitespace_operator."<space> :<C-U>exe '.,+'.v:count' StripWhitespace'<CR>"
+    " Other motions
+    exe "nmap <silent> ".g:better_whitespace_operator."        :<C-U>set opfunc=<SID>StripWhitespaceMotion<CR>g@"
+endif
+
 
 " Process auto commands upon load, update local enabled on filetype change
 autocmd FileType * let b:better_whitespace_enabled = !<SID>ShouldSkipHighlight() | call <SID>SetupAutoCommands()


### PR DESCRIPTION
Closes #18, but the default is a little awkward. Any operator that has a prefix that is already a command (starting with <kbd>d</kbd> or <kbd>s</kbd> for example) is impossible, as then selecting + operator or operator + some motion gets interpreted differently as that command.

I went with <kbd>space</kbd> as a default for now, but that can be changed easily before merging if anyone comes up with a better idea.