### PR TITLE
Fixed check for empty better-whitespace-operator key

### DIFF
--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -291,7 +291,7 @@ command! CurrentLineWhitespaceOn call <SID>CurrentLineWhitespaceOn()
 command! -range=% NextTrailingWhitespace call <SID>GotoTrailingWhitespace(0, <line1>, <line2>)
 command! -range=% PrevTrailingWhitespace call <SID>GotoTrailingWhitespace(1, <line1>, <line2>)
 
-if !empty('g:better_whitespace_operator')
+if !empty(g:better_whitespace_operator)
     function! s:StripWhitespaceMotion(type)
         call <SID>StripWhitespace(line("'["), line("']"))
     endfunction


### PR DESCRIPTION
Before this commit, `g:better_whitespace_operator` was checked for
non-emptiness as a string which was always true. As a result, the
whitespace operator could not be disabled.