### PR TITLE
Update operator default to <leader>s

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ Whitespace highlighting is enabled by default, with a highlight color of red.
     the file that it cleans, either give it a range or select a group of lines
     in visual mode and then execute it.
 
-    *  There is an operator (defaulting to `<space>`) to clean whitespace.
-        For example, in normal mode, `<space>ip` will remove trailing whitespace from the
+    *  There is an operator (defaulting to `<leader>s`) to clean whitespace.
+        For example, in normal mode, `<leader>sip` will remove trailing whitespace from the
         current paragraph.
 
         You can change the operator it, for example to set it to _s, using:
@@ -88,6 +88,9 @@ Whitespace highlighting is enabled by default, with a highlight color of red.
         ```
         Now `<number>_s<space>` strips whitespace on \<number\> lines, and `_s<motion>` on the
         lines affected by the motion given. Set to the empty string to deactivate the operator.
+
+        Note: This operator will not be mapped if an existing, user-defined
+        mapping is detected for the provided operator value.
 
 *  To enable/disable stripping of extra whitespace on file save for a buffer, call one of:
     ```vim

--- a/doc/better-whitespace.txt
+++ b/doc/better-whitespace.txt
@@ -56,6 +56,14 @@ this option.
 Call :CurrentLineWhitespaceOn to enable whitespace highlighting for the current
 line. Highlighting is still disabled for the current line while in insert mode.
 
+                                                *operator*
+By default, an operator is provided mapped to: <leader>s.
+To modify the key mapping for this operator, set g:better_whitespace_operator.
+This operator will strip whitespace over the currently selected region in visual
+mode, or for the following motion in normal mode.
+Note: This operator will not be mapped if an existing, user-defined mapping is
+detected for the provided operator value.
+
 Repository exists at: http://github.com/ntpeters/vim-better-whitespace
 
 Originally inspired by: https://github.com/bronson/vim-trailing-whitespace

--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -16,7 +16,7 @@ function! s:InitVariable(var, value)
 endfunction
 
 " Operator for StripWhitespace (empty to disable)
-call s:InitVariable('g:better_whitespace_operator', '<space>')
+call s:InitVariable('g:better_whitespace_operator', '<leader>s')
 
 " Set this to enable/disable whitespace highlighting
 call s:InitVariable('g:better_whitespace_enabled', 1)
@@ -296,14 +296,24 @@ if !empty(g:better_whitespace_operator)
         call <SID>StripWhitespace(line("'["), line("']"))
     endfunction
 
-    " Visual mode
-    exe "xmap <silent> ".g:better_whitespace_operator." :StripWhitespace<CR>"
-    " Normal mode (+ space, with line count)
-    exe "nmap <silent> ".g:better_whitespace_operator."<space> :<C-U>exe '.,+'.v:count' StripWhitespace'<CR>"
-    " Other motions
-    exe "nmap <silent> ".g:better_whitespace_operator."        :<C-U>set opfunc=<SID>StripWhitespaceMotion<CR>g@"
-endif
+    " Ensure we only map if no identical, user-defined mapping already exists
+    if (empty(mapcheck(g:better_whitespace_operator, 'x')))
+        " Visual mode
+        exe "xmap <silent> ".g:better_whitespace_operator." :StripWhitespace<CR>"
+    else
+        call <SID>Echo("Whitespace operator not mapped for visual mode. Mapping already exists.")
+    endif
 
+    " Ensure we only map if no identical, user-defined mapping already exists
+    if (empty(mapcheck(g:better_whitespace_operator, 'n')))
+        " Normal mode (+ space, with line count)
+        exe "nmap <silent> ".g:better_whitespace_operator."<space> :<C-U>exe '.,+'.v:count' StripWhitespace'<CR>"
+        " Other motions
+        exe "nmap <silent> ".g:better_whitespace_operator."        :<C-U>set opfunc=<SID>StripWhitespaceMotion<CR>g@"
+    else
+        call <SID>Echo("Whitespace operator not mapped for normal mode. Mapping already exists.")
+    endif
+endif
 
 " Process auto commands upon load, update local enabled on filetype change
 autocmd FileType * call <SID>ShouldSkipHighlight() | call <SID>SetupAutoCommands()


### PR DESCRIPTION
This change updates the default operator mapping to `<leader>s`, and
adds a check to ensure the mapping does not already exist.

Fixes #78