### PR TITLE
Fix for 'Undefined variable' err when no FileType

### DIFF
--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -336,7 +336,7 @@ endif
 
 " Process auto commands upon load, update local enabled on filetype change
 autocmd FileType * call <SID>ShouldHighlight() | call <SID>SetupAutoCommands()
-autocmd WinEnter,BufWinEnter * call <SID>SetupAutoCommands()
+autocmd WinEnter,BufWinEnter * call <SID>ShouldHighlight() | call <SID>SetupAutoCommands()
 autocmd ColorScheme * call <SID>WhitespaceInit()
 
 function! s:PerformMatchHighlight(pattern)


### PR DESCRIPTION
With config:
```
let g:better_whitespace_enabled = 0
let g:strip_whitespace_on_save = 1
let g:better_whitespace_filetypes_blacklist=['diff', 'gitcommit', 'unite', 'qf', 'help']
```
when I open some file without recognized filetype (for example: `touch a; vim a`) I get:
```
"a" 0L, 0C                                                                                                                                                                                
Error detected while processing function <SNR>63_SetupAutoCommands[37]..<SNR>63_ShouldStripWhitespace:                                                                                    
line    3:                                                                                                                                                                                
E121: Undefined variable: b:better_whitespace_enabled                                                                                                                                     
E15: Invalid expression: b:better_whitespace_enabled < 0                                                                                                                                  
Press ENTER or type command to continue  
```

That fix solves the problem. Otherwise you can also call `call s:InitVariable('b:better_whitespace_enabled', -1)` in a better place.