### PR TITLE
Add a configurable variable to set the highlight color of trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ Whitespace highlighting is enabled by default, with a highlight color of red.
     ```vim
     highlight ExtraWhitespace ctermbg=<desired_color>
     ```
+   or
+
+    ```vim
+    let g:better_whitespace_ctermcolor='<desired_color>'
+    ```
+   Similarly, to set gui color:
+
+    ```vim
+    let g:better_whitespace_guicolor='<desired_color>'
+    ```
 
 *  To enable highlighting and stripping whitespace on save by default, use respectively
     ```vim

--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -15,6 +15,10 @@ function! s:InitVariable(var, value)
     endif
 endfunction
 
+" Set the highlight color for trailing whitespaces
+call s:InitVariable('g:better_whitespace_ctermcolor', 'red')
+call s:InitVariable('g:better_whitespace_guicolor', '#FF0000')
+
 " Operator for StripWhitespace (empty to disable)
 call s:InitVariable('g:better_whitespace_operator', '<leader>s')
 
@@ -90,7 +94,7 @@ endfunction
 function! s:WhitespaceInit()
     " Check if the user has already defined highlighting for this group
     if hlexists("ExtraWhitespace") == 0 || synIDattr(synIDtrans(hlID("ExtraWhitespace")), "bg") == -1
-        highlight ExtraWhitespace ctermbg = red guibg = #FF0000
+        execute 'highlight ExtraWhitespace ctermbg = '.g:better_whitespace_ctermcolor. ' guibg = '.g:better_whitespace_guicolor
     endif
     let s:better_whitespace_initialized = 1
 endfunction


### PR DESCRIPTION
I think it would be very self-contained and tidy if we can have all the features or configurations of the plugin to be configured by simply setting the corresponding global variables (This patch won't break anybody's configuration if they have already set the highlight group in their vimrc)