### PR TITLE
Add an option to pick the diff binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,13 @@ Whitespace highlighting is enabled by default, with a highlight color of red.
        let g:strip_only_modified_lines=0
        ```
 
+    *  You can override the binary used to check which lines have been modified in the file.
+       For example to force a 'diff' installed in a different prefix and ignoring the changes
+       due to tab expansions, you can set the following:
+       ```
+       let g:diff_binary='/usr/local/bin/diff -E'
+       ```
+
 *  To disable this plugin for specific file types, add the following to your `~/.vimrc`:
     ```vim
     let g:better_whitespace_filetypes_blacklist=['<filetype1>', '<filetype2>', '<etc>']

--- a/doc/better-whitespace.txt
+++ b/doc/better-whitespace.txt
@@ -67,7 +67,13 @@ Overrides `g:better_whitespace_enabled`, and can be manually overriden with
 `g:strip_only_modified_lines`                     (defaults to 0)
 When stripping whitespace on save, only perform the stripping on the lines
 that have been modified.
-Uses `diff`, which should be available on all platforms (see |E810|).
+Uses an external `diff` command set in `g:diff_binary`, which should be
+available on all platforms (see |E810|).
+
+`g:diff_binary`
+The binary to use to check which lines have been modified in a file. Defaults
+to 'diff' on windows and 'command diff' on unix-like platforms (linux, mac OS,
+etc.) to bypass any shell aliases or default options for diff.
 
 `g:strip_max_file_size`                           (defaults to 1000)
 Skip stripping whitespace on files that have more lines than the value in this

--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -65,6 +65,12 @@ call s:InitVariable('strip_max_file_size', 1000)
 " Disable verbosity by default
 call s:InitVariable('better_whitespace_verbosity', 0)
 
+" Bypass the aliases set for diff by default
+if has("win32") || has("win16")
+    call s:InitVariable('diff_binary', 'diff')
+else
+    call s:InitVariable('diff_binary', 'command diff')
+endif
 
 " Section: Whitespace matching setup
 
@@ -95,7 +101,7 @@ function! s:WhitespaceInit()
 endfunction
 
 " Diff command returning a space-separated list of ranges of new/modified lines (as first,last)
-let s:diff_cmd='diff -a --unchanged-group-format="" --old-group-format="" --new-group-format="%dF,%dL " --changed-group-format="%dF,%dL " '
+let s:diff_cmd=g:diff_binary.' -a --unchanged-group-format="" --old-group-format="" --new-group-format="%dF,%dL " --changed-group-format="%dF,%dL " '
 
 " Section: Actual work functions
 


### PR DESCRIPTION
Ignores aliases set in the shell by default, which closes #109