### PR TITLE
Fix EOF whitespace strip

### DIFF
--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -201,14 +201,7 @@ function! s:StripWhitespace(line1, line2)
 
     " Strip empty lines at EOF
     if g:strip_whitelines_at_eof == 1 && a:line2 >= line('$')
-        if &ff == 'dos'
-            let nl='\r\n'
-        elseif &ff == 'max'
-            let nl='\r'
-        else " unix
-            let nl='\n'
-        endif
-        silent execute '%s/\('.nl.'\)\+\%$//e'
+        silent execute '%s/\(\n\)\+\%$//e'
     endif
 
     " Restore the saved search and cursor position


### PR DESCRIPTION
Stripping EOF whitespace does not work outside of Unix formats. The pattern only needs the `\n` alone as it will match new lines on all file formats regardless of the actual `<EOL>` value written to the file.

Previously only stripping on Unix, now tested and working correctly on all formats after patch.