### PR TITLE
Add git to default blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,13 +162,13 @@ Whitespace highlighting is enabled by default, with a highlight color of red.
     This replaces the filetypes from the default list of blacklisted filetypes. The
     default types that are blacklisted are:
     ```vim
-    ['diff', 'gitcommit', 'unite', 'qf', 'help', 'markdown']
+    ['diff', 'git', 'gitcommit', 'unite', 'qf', 'help', 'markdown', 'fugitive']
     ```
     If you prefer to also keep these default filetypes ignored, simply include them in the
     blacklist:
     ```vim
     let g:better_whitespace_filetypes_blacklist=['<filetype1>', '<filetype2>', '<etc>',
-                                            'diff', 'gitcommit', 'unite', 'qf', 'help']
+                                            'diff', 'git', 'gitcommit', 'unite', 'qf', 'help', 'markdown', 'fugitive']
     ```
 
     This blacklist can be overriden on a per-buffer basis using the buffer toggle enable and

--- a/doc/better-whitespace.txt
+++ b/doc/better-whitespace.txt
@@ -58,8 +58,9 @@ PREFERENCES                                     *better-whitespace-preferences*
 `g:better_whitespace_enabled`                     (defaults to 1)
 Set this to enable whitespace highlighting by default, set to 0 to disable it.
 
-`g:better_whitespace_filetypes_blacklist`         (defaults to ['diff', 'gitcommit',
-                                                'unite', 'qf', 'help', 'markdown'])
+`g:better_whitespace_filetypes_blacklist`         (defaults to ['diff', 'git',
+                                                'gitcommit','unite', 'qf', 'help',
+                                                'markdown', 'fugitive'])
 Disables better-whitespace by default on these file types.
 Overrides `g:better_whitespace_enabled`, and can be manually overriden with
 |better-whitespace-:EnableWhitespace| and related commands.

--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -51,7 +51,7 @@ call s:InitVariable('strip_whitelines_at_eof', 0)
 call s:InitVariable('strip_whitespace_confirm', 1)
 
 " Set this to blacklist specific filetypes
-call s:InitVariable('better_whitespace_filetypes_blacklist', ['diff', 'gitcommit', 'unite', 'qf', 'help', 'markdown', 'fugitive'])
+call s:InitVariable('better_whitespace_filetypes_blacklist', ['diff', 'git', 'gitcommit', 'unite', 'qf', 'help', 'markdown', 'fugitive'])
 
 " Skip empty (whitespace-only) lines for highlighting
 call s:InitVariable('better_whitespace_skip_empty_lines', 0)


### PR DESCRIPTION
Git diffs routinely contain trailing whitespace. The excess highlights
are rather distracting.