### PR TITLE
Fix Infinte loop in RestoreSearchHistory

### DIFF
--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -118,7 +118,7 @@ endif
 
 " Function that clears the search entries of BetterWhiteSpace by rolling back to the given index
 function! s:RestoreSearchHistory(index)
-    while histnr('search') > a:index
+    while a:index != -1 && histnr('search') > a:index
         call histdel('search', -1)
     endwhile
     let @/ = histget('search', -1)

--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -118,7 +118,7 @@ endif
 
 " Function that clears the search entries of BetterWhiteSpace by rolling back to the given index
 function! s:RestoreSearchHistory(index)
-    while a:index != -1 && histnr('search') > a:index
+    while histnr('search') > max([a:index, 0])
         call histdel('search', -1)
     endwhile
     let @/ = histget('search', -1)


### PR DESCRIPTION
Fixed an infinte loop in RestoreSearchHistory when the index parameter is equal to -1. This happens when vim is started for the very first time.