### PR TITLE
Nvim term fix

### DIFF
--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -387,6 +387,13 @@ endfunction
 autocmd FileType,WinEnter,BufWinEnter * call <SID>SetupAutoCommands()
 autocmd ColorScheme * call <SID>WhitespaceInit()
 
+" Also check on specific buftype changes
+if has('nvim')
+    autocmd TermOpen * call <SID>SetupAutoCommands()
+else
+    autocmd TerminalWinOpen * call <SID>SetupAutoCommands()
+endif
+
 
 " Section: Setting of per-buffer higlighting/stripping
 

--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -172,7 +172,8 @@ else
     function! s:HighlightEOLWhitespace()
         call <SID>ClearHighlighting()
         if <SID>ShouldHighlight()
-            let s:match_id = matchadd('ExtraWhitespace', s:eol_whitespace_pattern, 10, get(s:, 'match_id', -1))
+            let w:better_whitespace_match_id = matchadd('ExtraWhitespace',
+                        \  s:eol_whitespace_pattern, 10, get(w:, 'better_whitespace_match_id', -1))
         endif
     endfunction
 
@@ -180,15 +181,19 @@ else
     function! s:HighlightEOLWhitespaceExceptCurrentLine()
         call <SID>ClearHighlighting()
         if <SID>ShouldHighlight()
-            let s:match_id = matchadd('ExtraWhitespace',
+            let w:better_whitespace_match_id = matchadd('ExtraWhitespace',
                         \   '\%<' . line('.') .  'l' . s:eol_whitespace_pattern .
-                        \ '\|\%>' . line('.') .  'l' . s:eol_whitespace_pattern, 10, get(s:, 'match_id', -1))
+                        \ '\|\%>' . line('.') .  'l' . s:eol_whitespace_pattern, 10, get(w:, 'better_whitespace_match_id', -1))
         endif
     endfunction
 
     " Remove Whitespace matching
     function! s:ClearHighlighting()
-        silent! call matchdelete(get(s:, 'match_id', -1))
+        let match_id = get(w:, 'better_whitespace_match_id', -1)
+        let valid_ids = map(getmatches(), 'v:val["id"]')
+        if match_id >= 0 && index(valid_ids, match_id) >= 0
+            call matchdelete(match_id)
+        endif
     endfunction
 endif
 


### PR DESCRIPTION
Triggers our detection again when the `term` buftype is set − different events in vim and neovim.