### PR TITLE
Ignore TerminalWinOpen event when not supported

### DIFF
--- a/plugin/better-whitespace.vim
+++ b/plugin/better-whitespace.vim
@@ -390,7 +390,7 @@ autocmd ColorScheme * call <SID>WhitespaceInit()
 " Also check on specific buftype changes
 if has('nvim')
     autocmd TermOpen * call <SID>SetupAutoCommands()
-else
+elseif exists('##TerminalWinOpen')
     autocmd TerminalWinOpen * call <SID>SetupAutoCommands()
 endif
 


### PR DESCRIPTION
In #161, a non-Neovim fallback for terminal detection used the TerminalWinOpen event. This event was added in Vim 8.1.2219 (Oct 26, 2019), and is causing previous versions to complain at startup:

```
Error detected while processing /home/jbylsma/.vim/plugged/vim-better-whitespace/plugin/better-whitespace.vim:
line  394:
E216: No such group or event: TerminalWinOpen * call <SID>SetupAutoCommands()
Press ENTER or type command to continue
```

I'm noticing this on RHEL8.9 servers. Adding an "else if" check quiets the error.